### PR TITLE
Use clang-tidy "by the book"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,18 +19,10 @@ endif()
 
 option(ENABLE_CLANG_TIDY "Enable clang-tidy analysis." OFF)
 
-# Globally enable additional goodies, if we are compiling with clang.
+# Enable clang-tidy checks if user enables it and we have a clang toolchain
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND ENABLE_CLANG_TIDY)
-
-  # Optionally enable clang-tidy for the whole project.
-  find_program(CLANG_TIDY_EXE NAMES "clang-tidy" DOC "Path to clang-tidy executable")
-
-  if(CLANG_TIDY_EXE)
-    set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
-  else()
-    message(FATAL_ERROR "clang-tidy not found. Please install for automatic static analysis.")
-  endif()
-
+  find_program(CLANG_TIDY_EXECUTABLE clang-tidy REQUIRED)
+  set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR})
 endif()
 
 include_directories(include)

--- a/nix/clang-tidy.nix
+++ b/nix/clang-tidy.nix
@@ -1,4 +1,4 @@
-{ pkgs, hedron }:
+{ clang-tools, hedron }:
 hedron.overrideAttrs (
   old: {
     name = "hedron-clang-tidy";
@@ -6,8 +6,6 @@ hedron.overrideAttrs (
       "-DENABLE_CLANG_TIDY=ON"
       "-DBUILD_TESTING=ON"
     ];
-    nativeBuildInputs = old.nativeBuildInputs or [] ++ [
-      pkgs.clang-tools
-    ];
+    nativeBuildInputs = old.nativeBuildInputs or [] ++ [ clang-tools ];
   }
 )


### PR DESCRIPTION
I just read how to use static analysis correctly in cmake in @craigscott-crascit's cmake book (new chapter) and thought of this repo.

These changes improve the code in a way that:

- error handling code can be removed by using `REQUIRED` in the clang-tidy search
- the `-p` param is used with clang-tidy which can remove some potential problems (didn't seem to happen here but it's still the suggested way to do this as the book explains after the author has seen problems)
- normalized the nix expression (better overrideability)